### PR TITLE
PRO-5106: pass on widget options to AposWidget during full page render

### DIFF
--- a/components/AposArea.astro
+++ b/components/AposArea.astro
@@ -23,7 +23,7 @@ const Wrapper = isEdit ? 'div' : Fragment
 <Wrapper {...attributes}>
 {widgets?.map((item) => {
     return (
-        <AposWidget widget={item} {...props}/>
+        <AposWidget widget={item} options={area.options.widgets[item.type]} {...props}/>
     )
     })}
 </Wrapper>


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

The other half of the fix: astro-integration now finds widget options correctly on the area object during full page renders.

## What are the specific steps to test this change?

* Get the latest `main` of the `astro-demo` project (NOTE: I updated it) and the latest `astro-demo-core` branch of `starter-kit-essentials` (NOTE I updated this too)
* `npm link` the `pro-5106` branch of `apostrophe` in `starter-kit-pro-essentials`
* `npm link` the `pro-5106` branch of the `apostrophecms/astro-integration` repo as `@michelin-cxf/astro-apostrophe-integration` in `apostrophecms/astro-demo`
* Adding the "house" widget to any area results in an immediate rendering of a 37 pixel house emoji
* Refreshing the page then also shows the 37 pixel house emoji

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
