### PR TITLE
Alter entrypoint to work with Astro 3.x or 4.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,38 +23,47 @@ export default function apostropheIntegration(options) {
             ],
           },
         });
-        
+        // duplication of entrypoint needed for Astro 3.x support per
+        // https://docs.astro.build/en/guides/upgrade-to/v4/#renamed-entrypoint-integrations-api
         injectRoute({
           pattern: '/apos-frontend/[...slug]',
-          entryPoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js'
+          entryPoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js',
+          entrypoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js'
         });
         injectRoute({
           pattern: '/api/v1/[...slug]',
-          entryPoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js'
+          entryPoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js',
+          entrypoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js'
         });
         injectRoute({
           pattern: '/[locale]/api/v1/[...slug]',
-          entryPoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js'
+          entryPoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js',
+          entrypoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js'
         });
         injectRoute({
           pattern: '/api/v1/@apostrophecms/area/render-widget',
-          entryPoint: '@apostrophecms/astro-integration/endpoints/renderWidget.astro'
+          entryPoint: '@apostrophecms/astro-integration/endpoints/renderWidget.astro',
+          entrypoint: '@apostrophecms/astro-integration/endpoints/renderWidget.astro'
         });
         injectRoute({
           pattern: '/[locale]/api/v1/@apostrophecms/area/render-widget',
-          entryPoint: '@apostrophecms/astro-integration/endpoints/renderWidget.astro'
+          entryPoint: '@apostrophecms/astro-integration/endpoints/renderWidget.astro',
+          entrypoint: '@apostrophecms/astro-integration/endpoints/renderWidget.astro'
         });
         injectRoute({
           pattern: '/login',
-          entryPoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js'
+          entryPoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js',
+          entrypoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js'
         });
         injectRoute({
           pattern: '/[locale]/login',
-          entryPoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js'
+          entryPoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js',
+          entrypoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js'
         });
         injectRoute({
           pattern: '/uploads/[...slug]',
-          entryPoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js'
+          entryPoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js',
+          entrypoint: '@apostrophecms/astro-integration/endpoints/aposProxy.js'
         });
       }
     }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
This PR updates the route injection to work with either Astro 3.x or 4.x. This requires an entry for both the old `entryPoint` and the new `entry point`. Per `https://docs.astro.build/en/guides/upgrade-to/v4/#renamed-entrypoint-integrations-api`

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
