### PR TITLE
release 1.0.2, PRO-5334

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.2 (2023-12-22)
+
+* Fix bug causing pages to crash after refresh if widget
+grouping is used.
+
 ## 1.0.1 (2023-12-21)
 
 * Fix bug impacting two-column widgets.

--- a/components/AposArea.astro
+++ b/components/AposArea.astro
@@ -19,11 +19,34 @@ if (isEdit) {
   };
 }
 const Wrapper = isEdit ? 'div' : Fragment;
+const widgetOptions = getWidgetOptions(area.options);
+
+function getWidgetOptions(options) {
+  let widgets = options.widgets || {};
+
+  if (options.groups) {
+    for (const group of Object.keys(options.groups)) {
+      widgets = {
+        ...widgets,
+        ...options.groups[group].widgets
+      };
+    }
+  }
+  return widgets;
+}
+
+function mergeWidgets(groups:Record<string,Record<string,Object>>) {
+  const widgetOptions = {};
+  for (const group of Object.values(groups)) {
+    Object.assign(widgets, group.widgets || {});
+  }
+  return widgetOptions;
+}
 ---
 <Wrapper {...attributes}>
 {widgets?.map((item) => {
   return (
-    <AposWidget widget={item} options={area.options.widgets[item.type]} {...props}/>
+    <AposWidget widget={item} options={widgetOptions[item.type]} {...props}/>
   )
   })}
 </Wrapper>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apostrophecms/apostrophe-astro",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "description": "Apostrophe integration for Astro",
   "main": "index.js",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Areas using expanded widget groups were crashing in Astro, see PRO-5334 for specifics.

## What are the specific steps to test this change?

I've tested it using the `grouped-widgets` branch of `starter-kit-astro`, where this issue comes into play on default page templates (not other page templates like home).

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
