### PR TITLE
make it optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## 1.0.5 (2024-02-07)
 
-* Compatible with Astro's `ViewTransition` feature when editing.
+* Compatible with Astro's `ViewTransition` feature when editing, via
+a workaround. Since this workaround imposes a performance penalty
+(only for editors, not the public), the `viewTransitionWorkaround`
+option must be set to `true` to enable it.
 
 ## 1.0.4 (2024-01-22)
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ export default defineConfig({
       aposHost: 'http://localhost:3000',
       widgetsMapping: './src/widgets',
       templatesMapping: './src/templates',
+      viewTransitionWorkaround: false,
       forwardHeaders: [
         'content-security-policy', 
         'strict-transport-security', 
@@ -141,6 +142,16 @@ The file in your project that contains the mapping between Apostrophe widget typ
 ### `templatesMapping` (mandatory)
 
 The file in your project that contains the mapping between Apostrophe templates and your Astro templates (see below).
+
+### `viewTransitionWorkaround` (optional)
+
+If set to `true`, Apostrophe will refresh its admin UI JavaScript on
+every page transition, to ensure compatibility with Astro
+[view transitions](https://docs.astro.build/en/guides/view-transitions/).
+If you are not using this feature of Astro, you can omit this flag to
+improve performance for editors. Ordinary website visitors are
+not impacted in any case. We are seeking an alternative solution to
+eliminate this option.
 
 ### `forwardHeaders`  
 

--- a/components/layouts/AposEditLayout.astro
+++ b/components/layouts/AposEditLayout.astro
@@ -1,6 +1,9 @@
 ---
-const { title, bodyClass, aposData, lang } = Astro.props
-const bundleSrc = `${aposData.aposBodyData?.assetBaseUrl}/apos-module-bundle.js?vt=${new Date().getTime()}`
+const { title, bodyClass, aposData, lang } = Astro.props;
+import config from 'virtual:apostrophe-config';
+const { viewTransitionWorkaround } = config;
+const cacheBuster = viewTransitionWorkaround ? `?cb=${new Date().getTime()}` : '';
+const bundleSrc = `${aposData.aposBodyData?.assetBaseUrl}/apos-module-bundle.js${cacheBuster}`;
 ---
 
 <!DOCTYPE html>

--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ export default function apostropheIntegration(options) {
               ),
               vitePluginApostropheConfig(
                 options.aposHost,
-                options.forwardHeaders
+                options.forwardHeaders,
+                options.viewTransitionWorkaround
               ),
             ],
           },

--- a/vite/vite-plugin-apostrophe-config.js
+++ b/vite/vite-plugin-apostrophe-config.js
@@ -1,4 +1,8 @@
-export function vitePluginApostropheConfig(aposHost, forwardHeaders) {
+export function vitePluginApostropheConfig(
+  aposHost,
+  forwardHeaders,
+  viewTransitionWorkaround
+) {
 
   const virtualModuleId = "virtual:apostrophe-config";
   const resolvedVirtualModuleId = "\0" + virtualModuleId;
@@ -13,7 +17,16 @@ export function vitePluginApostropheConfig(aposHost, forwardHeaders) {
     async load(id) {
       if (id === resolvedVirtualModuleId) {
           return `
-          export default { aposHost: "${aposHost}" ${forwardHeaders ? `, forwardHeaders: ${JSON.stringify(forwardHeaders)}` : ''} }`
+            export default {
+              aposHost: "${aposHost}"
+              ${forwardHeaders ? `,
+                forwardHeaders: ${JSON.stringify(forwardHeaders)}` : ''
+              }
+              ${viewTransitionWorkaround ? `,
+                viewTransitionWorkaround: true` : ''
+              }
+            }`
+          ;
       }
     },
   };


### PR DESCRIPTION
With this option, we're more comfortable shipping the workaround. We have a ticket to research a better long-term fix.

Both the original problem and the workaround can be demonstrated using the `pro-5612-example` branch of `astro-frontend`. I added a very simple navigation `ul` to every page allowing you to access subpages through a "normal" link, and I enabled the `ViewTransition` feature of Astro as well as the option for our workaround (when this branch is present).

If `@apostrophecms/apostrophe-astro` is the current release (not `main` or this branch), which is what you'll get with your initial `npm install` of `pro-5612-example`, then a logged-in editor using my navigation link to get from the homepage to a subpage should see the admin bar disappear.

If `@apostrophecms/apostrophe-astro` is this branch (e.g. npm link it in), then the admin bar should survive the page transition.

I have done these tests.