### PR TITLE
Fix server crash on renderWidget route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* The `renderWidget` route will no longer crash if there was an issue getting the `render-widget` route from Apostrophe (like a mandatory field missing), it will respond with a 500 only, with a log in the console.
+
 ## 1.0.7 (2024-03-28)
 
 * Visiting the `/login` page when already logged in no longer results in

--- a/endpoints/renderWidget.astro
+++ b/endpoints/renderWidget.astro
@@ -13,6 +13,8 @@ request.headers.set('apos-external-front-key', key);
 const response = await aposResponse(request);
 const responseBody = await response.json();
 const { widget, ...props } = responseBody;
-
+if (!widget) {
+  throw new Error('There was an issue while rendering the widget in the renderWidget endpoint.');
+}
 ---
 <AposWidget {widget} {...props} />


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fixes a crash on the renderWidget route if there was an issue when getting the response from render-widget Apostrophe route like a missing mandatory field.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
