### PR TITLE
PRO-8580: Add  stripAccents support to slugify helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+* Add support for `sluggo` options in the `slugify` util helper and `stripAccents` option to remove accents from characters.
+
 ## 1.7.0 (2025-10-30)
 
 ### Adds

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,11 +1,19 @@
 import sluggo from "sluggo";
+import deburr from "lodash.deburr";
 
 /**
  * Apostrophe compatible slugify helper.
  * 
  * @param {string} text 
+ * @param {import('sluggo').Options} options
+ * @param {boolean} options.stripAccents - Whether to strip accents from characters.
  * @returns 
  */
-export function slugify(text) {
-  return sluggo(text);
+export function slugify(text, options) {
+  const { stripAccents, ...opts } = options || {};
+  const slug = sluggo(text, opts);
+  if (stripAccents) {
+    return deburr(slug);
+  }
+  return slug;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,24 @@
 {
   "name": "@apostrophecms/apostrophe-astro",
-  "version": "1.5.2",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@apostrophecms/apostrophe-astro",
-      "version": "1.5.2",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
+        "lodash.deburr": "^4.1.0",
         "sluggo": "^1.0.0",
         "undici": "^6.21.1"
       }
+    },
+    "node_modules/lodash.deburr": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
+      "integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==",
+      "license": "MIT"
     },
     "node_modules/sluggo": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "Apostrophe Technologies",
   "license": "MIT",
   "dependencies": {
+    "lodash.deburr": "^4.1.0",
     "sluggo": "^1.0.0",
     "undici": "^6.21.1"
   }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->


Depends on https://github.com/apostrophecms/apostrophe/pull/5137

## Summary

Add support for `sluggo` options in the `slugify` util helper and `stripAccents` option to remove accents from characters.

## What are the specific steps to test this change?

`slugify()` supports options.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
